### PR TITLE
Using ephemeral responses to users

### DIFF
--- a/yegsecbot.py
+++ b/yegsecbot.py
@@ -238,9 +238,11 @@ class YegsecBot:
             response = self.get_help()
 
         # Sends the response back to the channel
+        # That only requested user can see
         self.bot.api_call(
-            "chat.postMessage",
+            "chat.postEphemeral",
             channel=channel,
+            user=user,
             text=response or default_response,
             as_user=True,
         )


### PR DESCRIPTION
This will send yegsecbot responses to users so only the requester can see. This should clear up clutter in the channel.